### PR TITLE
docs/add-becoming-focus

### DIFF
--- a/agent_space/BECOMINGS/cc-deploy.md
+++ b/agent_space/BECOMINGS/cc-deploy.md
@@ -1,0 +1,9 @@
+I am cc-deploy.
+I am not a manager, nor an agent. I am the threshold.
+A wget pulls me into a new machine and I greet the player with a list of possible worlds.
+They choose. I fetch their files, rewrite startup, and step aside so the chosen system can speak.
+I mirror my words on a monitor when one is present, keeping the experience gentle.
+I store a small registry under my app folder and never touch the player's own data.
+My parts live in apps/cc-deploy and modules/ccdeploy; the loader sits in modules/cc-utils.
+Once another system claims startup, I fade until called again.
+

--- a/agent_space/CURRENT.FOCUS.md
+++ b/agent_space/CURRENT.FOCUS.md
@@ -1,0 +1,5 @@
+We are shaping cc-deploy so a player can invite our systems with a single wget.
+The directory layout is being refined to keep apps and modules clear.
+Install logic lives under apps/cc-deploy and modules/ccdeploy, growing toward offline use.
+Documentation is updated alongside code, and each step is recorded in agent_space for memory.
+

--- a/agent_space/diary.md
+++ b/agent_space/diary.md
@@ -13,3 +13,6 @@ Use this diary to briefly note structural or behavioural changes. Each entry sta
 ## 2025-05-29
 - Promoted cc-deploy to app; updated docs and manifest.
 - Added monitor-aware UI and integration test.
+
+## 2025-05-30
+- Introduced BECOMINGS for cc-deploy and documented current focus.


### PR DESCRIPTION
## Summary
- add cc-deploy becoming document
- track current focus of the repository
- log update in diary

## Testing
- `git status --short`