### PR TITLE
core/context-driven-deploy

### DIFF
--- a/agent_space/diary.md
+++ b/agent_space/diary.md
@@ -40,3 +40,10 @@ Use this diary to briefly note structural or behavioural changes. Each entry sta
 
 ## 2025-05-29
 - From now on active development will happen on branch 'dev'
+
+## 2025-05-29
+- Scanned repo for legacy requires bypassing context.
+- Found: apps/cc-deploy/init.lua, apps/cc-deploy/install.lua, apps/cc-deploy/recursive.lua, dev/test_cc_deploy.lua.
+- Refactored apps/cc-deploy/install.lua to load via context.
+- Updated init.lua, recursive.lua, start.lua, and context.lua for context-driven loading.
+- Added waitForInput helper and adjusted tests to use context.

--- a/apps/cc-deploy/init.lua
+++ b/apps/cc-deploy/init.lua
@@ -1,49 +1,53 @@
 -- apps/cc-deploy/init.lua
 -- Simple terminal UI for installing systems
 
-local require_mod = dofile("cc-systems/modules/cc-utils/require.lua")
-local hui = require_mod("modules.cc-hui.ui")
-local deploy = require_mod("apps.cc-deploy.install")
+return function(context)
+  local hui = context.hui
+  local deploy = context.install
 
-hui.init()
+  hui.init()
 
-local root_manifest = dofile("cc-systems/meta/manifest.lua")
+  local root_manifest = context.root_manifest
 
-local function choose(options)
-  return hui.choose(options, "Select system: ")
-end
-
-local function load_manifest(path)
-  local modPath = path:gsub("/", "."):gsub("%.lua$", "")
-  return require_mod(modPath)
-end
-
-local function main()
-  hui.clear()
-  local systems = {}
-  for _, entry in ipairs(root_manifest.systems or {}) do
-    table.insert(systems, load_manifest(entry))
+  local function choose(options)
+    return hui.choose(options, "Select system: ")
   end
 
-  if #systems == 0 then
-    hui.print("No systems available.")
-    return
+  local function load_manifest(path)
+    local key = path:gsub("[/%.]", "_")
+    if not context[key] then
+      context._load(key, path)
+    end
+    return context[key]
   end
 
-  local choice = choose(systems)
-  if not choice then return end
+  local function main()
+    hui.clear()
+    local systems = {}
+    for _, entry in ipairs(root_manifest.systems or {}) do
+      table.insert(systems, load_manifest(entry))
+    end
 
-  hui.print("Installing " .. choice.id .. "...")
-  deploy.install(choice, "")
-  if choice.entry then
-    local f = fs.open("startup.lua", "w")
-    f.write("shell.run('" .. choice.entry .. "')\n")
-    f.close()
-    hui.print("Startup updated -> " .. choice.entry)
+    if #systems == 0 then
+      hui.print("No systems available.")
+      return
+    end
+
+    local choice = choose(systems)
+    if not choice then return end
+
+    hui.print("Installing " .. choice.id .. "...")
+    deploy.install(choice, "")
+    if choice.entry then
+      local f = fs.open("startup.lua", "w")
+      f.write("shell.run('" .. choice.entry .. "')\n")
+      f.close()
+      hui.print("Startup updated -> " .. choice.entry)
+    end
+    hui.print("Done.")
+    hui.waitForInput("Press any key to reboot...")
+    os.reboot()
   end
-  hui.print("Done.")
-  hui.waitForInput("Press any key to reboot...")
-  os.reboot()
+
+  main()
 end
-
-main()

--- a/apps/cc-deploy/install.lua
+++ b/apps/cc-deploy/install.lua
@@ -1,10 +1,10 @@
 -- apps/cc-deploy/install.lua
 -- Basic installer logic for cc-deploy
 
-local require_mod = dofile("cc-systems/modules/cc-utils/require.lua")
-local registry = require_mod("apps.cc-deploy.registry")
+return function(context)
+  local registry = context.registry
 
-local install = {}
+  local install = {}
 
 local function ensureDir(path)
   local dir = fs.getDir(path)
@@ -26,18 +26,21 @@ local function copy(src, dst)
   out.close()
 end
 
-function install.install(manifest, root)
-  root = root or ""
-  for _, file in ipairs(manifest.files or {}) do
-    local src = fs.combine("cc-systems", root, file)
-    local dst = file
-    copy(src, dst)
+  function install.install(manifest, root)
+    root = root or ""
+    local base = context.root or ""
+    for _, file in ipairs(manifest.files or {}) do
+      local src = fs.combine(fs.combine(base, root), file)
+      local dst = file
+      copy(src, dst)
+    end
+    registry.record(manifest.id, manifest.version or "0")
   end
-  registry.record(manifest.id, manifest.version or "0")
-end
 
-function install.update(manifest, root)
-  install.install(manifest, root)
-end
 
-return install
+  function install.update(manifest, root)
+    install.install(manifest, root)
+  end
+
+  return install
+end

--- a/apps/cc-deploy/meta/manifest.lua
+++ b/apps/cc-deploy/meta/manifest.lua
@@ -11,7 +11,6 @@ return {
     "apps/cc-deploy/install.lua",
     "apps/cc-deploy/registry.lua",
     "apps/cc-deploy/recursive.lua",
-    "modules/cc-utils/require.lua",
     "modules/cc-hui/ui.lua"
   }
 }

--- a/context.lua
+++ b/context.lua
@@ -2,12 +2,20 @@
 local context = {}
 
 context._load = function (name, path)
-  local init = dofile(path)
-  context[name] = init(context)
+  local mod = dofile(path)
+  if type(mod) == "function" then
+    context[name] = mod(context)
+  else
+    context[name] = mod
+  end
 end
 
 -- load core modules
-
+context._load("hui", "modules/cc-hui/ui.lua")
+context._load("registry", "apps/cc-deploy/registry.lua")
+context._load("install", "apps/cc-deploy/install.lua")
+context._load("recursive", "apps/cc-deploy/recursive.lua")
+context._load("root_manifest", "meta/manifest.lua")
 
 -- load app
 context._app = function (path)

--- a/dev/test_cc_deploy.lua
+++ b/dev/test_cc_deploy.lua
@@ -85,8 +85,10 @@ term = term or {write=function() end, current=function() return {} end}
 function _G.write(txt) io.write(txt or "") end
 function _G.read() return "1" end
 shell = {run=function() end}
+os.reboot = function() end
 
-dofile("apps/cc-deploy/init.lua")
+local context = dofile("context.lua")
+context._app("apps/cc-deploy/init.lua")
 
 local f = io.open(tmp .. "/startup.lua", "r")
 assert(f, "startup.lua not written")

--- a/modules/cc-hui/ui.lua
+++ b/modules/cc-hui/ui.lua
@@ -56,4 +56,13 @@ function ui.choose(options, prompt)
   if idx then return options[idx] end
 end
 
+function ui.waitForInput(prompt)
+  ui.write(prompt or "Press any key...")
+  read()
+  if ui.monitor then
+    local x, y = ui.monitor.getCursorPos()
+    ui.monitor.setCursorPos(1, y + 1)
+  end
+end
+
 return ui

--- a/start.lua
+++ b/start.lua
@@ -105,3 +105,5 @@ for _, file in ipairs(manifest.files or {}) do
 end
 
 local context = dofile(ROOT .. "/context.lua")
+context.root = ROOT
+context._app(ROOT .. "apps/cc-deploy/init.lua")


### PR DESCRIPTION
## Summary
- route deploy modules through context loader
- expose waitForInput helper in cc-hui
- run cc-deploy via context from start.lua and tests
- document the migration in diary

## Testing
- `lua dev/test_cc_deploy.lua`