### PR TITLE
Introduce recursive manifest loader

### DIFF
--- a/agent_space/changelog.md
+++ b/agent_space/changelog.md
@@ -1,5 +1,7 @@
 ## 0.2.6 — dynamic manifest bootstrap
 - start.lua now reads manifests to fetch files.
+## 0.2.7 — recursive manifest loading
+- Added context._load helper and improved recursive loader.
 ## 0.2.5 — start.lua bootstrap
 - Implemented bootstrap to fetch cc-deploy files and run installer.
 

--- a/agent_space/diary.md
+++ b/agent_space/diary.md
@@ -53,3 +53,9 @@ Use this diary to briefly note structural or behavioural changes. Each entry sta
 - Updated cc-hui manifest type and root manifest listing.
 - Reworked cc-deploy init to install systems from manifests and update startup.
 - Adjusted integration test to use context loader.
+
+## 2025-06-05
+- Added context._load helper for single-file modules.
+- Normalized cc-deploy recursive loader to use context and default parameter.
+- Updated cc-deploy manifest to reference cc-hui manifest path.
+- Extended integration test to verify recursive manifest collection.

--- a/apps/cc-deploy/meta/manifest.lua
+++ b/apps/cc-deploy/meta/manifest.lua
@@ -12,6 +12,6 @@ return {
     "apps/cc-deploy/recursive.lua",
   },
   dependencies = {
-    "cc-hui",
+    "modules/cc-hui/meta/manifest.lua",
   }
 }

--- a/apps/cc-deploy/recursive.lua
+++ b/apps/cc-deploy/recursive.lua
@@ -1,11 +1,17 @@
 -- apps/cc-deploy/recursive.lua
 -- Helpers for nested manifests
 
-return function(context)
+return function(mod_context)
+  local context = mod_context or _G.context
+
   local function load_manifest(path)
     local key = path:gsub("[/%.]", "_")
     if not context[key] then
-      context._load(key, path)
+      if context._load then
+        context._load(key, path)
+      else
+        context[key] = context._loadFile(path, key)
+      end
     end
     return context[key]
   end

--- a/context.lua
+++ b/context.lua
@@ -23,10 +23,17 @@ context._loadFile = function (path, name)
     path = path
   })
 
-  if name then 
+  if name then
     context[name] = mod
   end
 
+  return mod
+end
+
+-- load a single module and store under a key
+context._load = function(name, path)
+  local mod = context._loadFile(path, name)
+  context[name] = mod
   return mod
 end
 

--- a/dev/test_cc_deploy.lua
+++ b/dev/test_cc_deploy.lua
@@ -120,6 +120,10 @@ context._registerModule("modules/cc-hui/", "cc-hui")
 context._registerModule("apps/cc-deploy/", "cc-deploy")
 context._startApp("cc-deploy")
 
+local manifest = dofile("apps/cc-deploy/meta/manifest.lua")
+local list = context["cc-deploy"].recursive.collect(manifest)
+assert(#list >= 2, "dependency not collected")
+
 local f = io.open(tmp .. "/startup.lua", "r")
 assert(f, "startup.lua not written")
 f:close()


### PR DESCRIPTION
## Summary
- let `context._load` register single files
- normalize `cc-deploy` recursive module to use the helper and default to `_G.context`
- reference `cc-hui` manifest path in `cc-deploy` manifest
- test recursive collection of manifests
- log the change in diary and changelog

## Testing
- `lua dev/test_cc_deploy.lua`