### PR TITLE
Fix cc-utils modules to use context._use

### DIFF
--- a/modules/cc-utils/bootstrap.lua
+++ b/modules/cc-utils/bootstrap.lua
@@ -1,14 +1,16 @@
 -- modules/cc-utils/bootstrap.lua
 -- This module provides file system utilities for the cc-utils library.
 
-return function () 
-  local ccUtils = context("cc-utils")
+return function ()
+  local ccUtils = context._use("cc-utils")
   local bootstrap = {}
 
   function bootstrap.autoUpdateStartup(starScriptUrl, targetFile)
-    local ACTUAL_FILE = "startup.lua"
-    local FILE_URL = ccUtils.net.joinUrl(config.BASE_URL, "start.lua")
-  
+    assert(type(starScriptUrl) == "string", "starScriptUrl must be a string")
+
+    local ACTUAL_FILE = targetFile or "startup.lua"
+    local FILE_URL = starScriptUrl
+
     local tempContent = ccUtils.net.fetch(FILE_URL)
   
     if not fs.exists(ACTUAL_FILE) then

--- a/modules/cc-utils/net.lua
+++ b/modules/cc-utils/net.lua
@@ -1,8 +1,8 @@
 -- modules/cc-utils/net.lua
 -- This module provides network utilities for the cc-utils library.
 
-return function () 
-  local ccUtils = context("cc-utils")
+return function ()
+  local ccUtils = context._use("cc-utils")
   local net = {}
 
   function net.fetch(url)


### PR DESCRIPTION
## Summary
- use `context._use` in `net.lua` and `bootstrap.lua`
- pass `starScriptUrl` directly for auto-update to remove `config.BASE_URL`

## Testing
- `luac -p modules/cc-utils/net.lua`
- `luac -p modules/cc-utils/bootstrap.lua`
